### PR TITLE
Halal Finance OS — full platform scaffold + auth, AI, Plaid, Stripe

### DIFF
--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "buildCommand": "cd frontend && npm install --legacy-peer-deps && npm run build",
+  "outputDirectory": "frontend/.next",
+  "installCommand": "cd frontend && npm install --legacy-peer-deps",
+  "framework": "nextjs",
+  "rootDirectory": "frontend"
+}


### PR DESCRIPTION
## Summary

- **Replaced** the existing repo content with a full-stack Halal Finance OS scaffold
- **Frontend:** Next.js 14 App Router (TypeScript, Tailwind CSS) — 13 routes covering landing page, auth, and all 6 product pillars (Investments, Credit Optimizer, Planning, Zakat, Real Estate, Education, AI Coach)
- **Backend:** Python FastAPI with SQLAlchemy, Alembic migrations, and 9 routers
- **Auth:** JWT via httpOnly cookie, `get_current_user` dependency, Next.js edge middleware protecting all dashboard routes, live login/signup forms, Zustand user store
- **AI Coach:** Claude `claude-sonnet-4-6` with SSE streaming and prompt caching; real-time character-by-character rendering; graceful error handling for missing API key / rate limits
- **Plaid:** Full Link token → public token exchange → holdings sync flow; AAOIFI screening applied to synced tickers; `PlaidLinkButton` component with SWR-based portfolio refresh
- **Stripe:** Checkout session creation, raw-body webhook handler for subscription lifecycle → `user.plan` updates, `require_plan()` gating on premium endpoints, `UpgradeModal` triggered automatically on 402 responses
- **Vercel:** `postcss.config.js` (was missing — caused unstyled UI), `vercel.json` setting `rootDirectory: frontend`
- **Alembic:** Initial migration covering `users`, `holdings`, `zakat_records`, `plaid_items`
- **Docs:** `docs/architecture.md`, `docs/product-spec.md`, `docs/api.md`

## Test plan

- [ ] Merge triggers Vercel redeploy — confirm UI is styled (green brand color, cards, sidebar visible)
- [ ] `/` landing page loads with hero, pricing tiers, feature pillars
- [ ] `/login` and `/signup` forms render and submit (requires backend)
- [ ] `/dashboard` and all sub-routes redirect to `/login` when unauthenticated
- [ ] `/investments/screening` — type MSFT/META/AMZN, verify ratio bars and compliance badge
- [ ] `/banking` — move sliders, click Generate, verify strategy output appears
- [ ] `/zakat` — enter values, click Calculate, verify Zakat amount and breakdown
- [ ] `/planning` — adjust inputs, click Build, verify on-track status and projections
- [ ] `/ai-coach` — requires `ANTHROPIC_API_KEY` env var set in Vercel; shows error banner gracefully if missing
- [ ] Run `alembic upgrade head` against a Postgres DB to verify migration applies cleanly
- [ ] Set `STRIPE_PRICE_*` env vars and test checkout redirect on a plan-gated route

https://claude.ai/code/session_01LgCGVgqQxshFpgqAM2jtqZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LgCGVgqQxshFpgqAM2jtqZ)_