### PR TITLE
fix: correct vercel.json — remove invalid rootDirectory property

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
-  "buildCommand": "cd frontend && npm install --legacy-peer-deps && npm run build",
-  "outputDirectory": "frontend/.next",
-  "installCommand": "cd frontend && npm install --legacy-peer-deps",
+  "buildCommand": "npm run build",
+  "outputDirectory": ".next",
+  "installCommand": "npm install --legacy-peer-deps",
   "framework": "nextjs",
   "rootDirectory": "frontend"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,6 @@
 {
-  "buildCommand": "npm run build",
-  "outputDirectory": ".next",
-  "installCommand": "npm install --legacy-peer-deps",
-  "framework": "nextjs",
-  "rootDirectory": "frontend"
+  "buildCommand": "cd frontend && npm install --legacy-peer-deps && npm run build",
+  "outputDirectory": "frontend/.next",
+  "installCommand": "cd frontend && npm install --legacy-peer-deps",
+  "framework": "nextjs"
 }


### PR DESCRIPTION
## Summary
- Removed `rootDirectory` from `vercel.json` — it is not a valid schema property and caused Vercel deployment to fail with a schema validation error
- Restored full paths from repo root (`cd frontend && ...` build commands, `frontend/.next` output directory)

## Test plan
- [ ] Vercel deployment on PR succeeds (no schema validation error)
- [ ] Preview URL loads with full Tailwind CSS styling
- [ ] Merge into master triggers production redeploy

---
_Generated by [Claude Code](https://claude.ai/code/session_01LgCGVgqQxshFpgqAM2jtqZ)_