### PR TITLE
fix: vercel.json — use paths relative to frontend/ rootDirectory

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
-  "buildCommand": "cd frontend && npm install --legacy-peer-deps && npm run build",
-  "outputDirectory": "frontend/.next",
-  "installCommand": "cd frontend && npm install --legacy-peer-deps",
+  "buildCommand": "npm run build",
+  "outputDirectory": ".next",
+  "installCommand": "npm install --legacy-peer-deps",
   "framework": "nextjs"
 }


### PR DESCRIPTION
## Summary
- Vercel dashboard has `rootDirectory` set to `frontend/`, so all commands already run from inside that directory
- Removed `cd frontend &&` prefixes and changed `outputDirectory` from `frontend/.next` to `.next`

## Test plan
- [ ] Vercel build succeeds (no `cd: frontend: No such file or directory`)
- [ ] Preview URL loads with full Tailwind CSS styling

---
_Generated by [Claude Code](https://claude.ai/code/session_01LgCGVgqQxshFpgqAM2jtqZ)_