### PR TITLE
fix: convert tailwind.config to .js so Tailwind can scan content paths

### DIFF
--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,6 +1,5 @@
-import type { Config } from "tailwindcss";
-
-const config: Config = {
+/** @type {import('tailwindcss').Config} */
+module.exports = {
   content: [
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
@@ -42,5 +41,3 @@ const config: Config = {
   },
   plugins: [],
 };
-
-export default config;

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,5 @@
 {
-  "buildCommand": "npm run build",
-  "outputDirectory": ".next",
   "installCommand": "npm install --legacy-peer-deps",
+  "buildCommand": "npm run build",
   "framework": "nextjs"
 }


### PR DESCRIPTION
## Summary
- Converted `tailwind.config.ts` → `tailwind.config.js` (CommonJS) — TypeScript Tailwind configs require `ts-node` to be transpiled at build time; without it Tailwind silently fails to scan content paths and purges all CSS
- Removed `outputDirectory` from `vercel.json` — letting Vercel's native Next.js builder handle output automatically avoids conflicts with its CSS asset pipeline

## Root cause
Build succeeded but zero CSS was rendered because `tailwind.config.ts` was not being transpiled, so Tailwind's content scanner found no files and purged every utility class.

## Test plan
- [ ] Vercel build succeeds
- [ ] Preview URL shows full Tailwind styling (colors, spacing, layout)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LgCGVgqQxshFpgqAM2jtqZ)_